### PR TITLE
feat: single-line request logging and tool exec warnings

### DIFF
--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -1,18 +1,21 @@
+import type { Logger } from "pino";
 import { createLogger } from "../logger.js";
 import type { CallNext, MiddlewareContext } from "../types.js";
 import { Middleware } from "./base.js";
 
-const logger = createLogger("arcade-mcp-middleware");
+const defaultLogger = createLogger("arcade-mcp-middleware");
 
 /**
- * Logging middleware. Logs request/response timing and errors.
+ * Logging middleware. Emits a single combined log line per request with method, timing, and status.
  */
 export class LoggingMiddleware extends Middleware {
   private logLevel: string;
+  private logger: Logger;
 
-  constructor(logLevel = "INFO") {
+  constructor(logLevel = "INFO", logger?: Logger) {
     super();
     this.logLevel = logLevel.toLowerCase();
+    this.logger = logger ?? defaultLogger;
   }
 
   override async onMessage(
@@ -21,69 +24,41 @@ export class LoggingMiddleware extends Middleware {
   ): Promise<unknown> {
     const start = performance.now();
 
-    this.logRequest(context);
-
     try {
       const result = await next(context);
       const elapsed = performance.now() - start;
-      this.logResponse(context, result, elapsed);
+      this.logCompleted(context, elapsed);
       return result;
     } catch (error) {
       const elapsed = performance.now() - start;
-      this.logError(context, error, elapsed);
+      this.logCompleted(context, elapsed, error);
       throw error;
     }
   }
 
-  private logRequest(context: MiddlewareContext): void {
-    const meta = {
-      type: context.type,
+  private logCompleted(
+    context: MiddlewareContext,
+    elapsed: number,
+    error?: unknown,
+  ): void {
+    const meta: Record<string, unknown> = {
       method: context.method,
       requestId: context.requestId,
       sessionId: context.sessionId,
+      elapsed: `${elapsed.toFixed(1)}ms`,
     };
 
-    switch (this.logLevel) {
-      case "debug":
-        logger.debug(meta, `[${context.type.toUpperCase()}] ${context.method}`);
-        break;
-      default:
-        logger.info(meta, `[${context.type.toUpperCase()}] ${context.method}`);
+    if (error) {
+      const errorName =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      meta.error = `${errorName}: ${errorMessage}`;
+      this.logger.error(meta, `${context.method} ${meta.elapsed}`);
+    } else if (this.logLevel === "debug") {
+      this.logger.debug(meta, `${context.method} ${meta.elapsed}`);
+    } else {
+      this.logger.info(meta, `${context.method} ${meta.elapsed}`);
     }
-  }
-
-  private logResponse(
-    context: MiddlewareContext,
-    _result: unknown,
-    elapsed: number,
-  ): void {
-    logger.info(
-      {
-        method: context.method,
-        requestId: context.requestId,
-        elapsed: `${elapsed.toFixed(1)}ms`,
-      },
-      `[RESPONSE] ${context.method}`,
-    );
-  }
-
-  private logError(
-    context: MiddlewareContext,
-    error: unknown,
-    elapsed: number,
-  ): void {
-    const errorName =
-      error instanceof Error ? error.constructor.name : "UnknownError";
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    logger.error(
-      {
-        method: context.method,
-        requestId: context.requestId,
-        elapsed: `${elapsed.toFixed(1)}ms`,
-        error: `${errorName}: ${errorMessage}`,
-      },
-      `[ERROR] ${context.method}`,
-    );
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -303,6 +303,16 @@ export class ArcadeMCPServer {
     const executeInner = async (): Promise<CallToolResult> => {
       const toolCtxData = this.buildToolContext(tool);
 
+      // Warn about missing secrets
+      if (tool.secrets && tool.secrets.length > 0) {
+        const missing = tool.secrets.filter((s) => !(s in toolCtxData.secrets));
+        if (missing.length > 0) {
+          _logger.warn(
+            `Tool "${tool.fullyQualifiedName}" missing required secrets: [${missing.join(", ")}]`,
+          );
+        }
+      }
+
       // Resolve auth token if needed
       if (tool.auth && !toolCtxData.authToken) {
         _logger.debug(
@@ -313,8 +323,8 @@ export class ArcadeMCPServer {
           toolCtxData.userId,
         );
         if (authResult.error) {
-          _logger.debug(
-            `Auth resolution for "${tool.fullyQualifiedName}" returned error to client`,
+          _logger.warn(
+            `Tool "${tool.fullyQualifiedName}" auth failed (provider=${tool.auth.providerId})`,
           );
           return authResult.error;
         }

--- a/tests/middleware/logging.test.ts
+++ b/tests/middleware/logging.test.ts
@@ -1,0 +1,96 @@
+import type { Logger } from "pino";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LoggingMiddleware } from "../../src/middleware/logging.js";
+import { makeMiddlewareContext } from "../helpers.js";
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+  } as unknown as Logger & {
+    info: ReturnType<typeof vi.fn>;
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("LoggingMiddleware", () => {
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockLogger = createMockLogger();
+  });
+
+  it("emits a single info line on success", async () => {
+    const mw = new LoggingMiddleware("INFO", mockLogger);
+    const ctx = makeMiddlewareContext({
+      requestId: "req-42",
+      sessionId: "sess-1",
+    });
+
+    await mw.handle(ctx, async () => "ok");
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    const [meta, msg] = mockLogger.info.mock.calls[0];
+    expect(meta.method).toBe("tools/call");
+    expect(meta.requestId).toBe("req-42");
+    expect(meta.sessionId).toBe("sess-1");
+    expect(meta.elapsed).toMatch(/^\d+\.\d+ms$/);
+    expect(msg).toContain("tools/call");
+    expect(msg).toContain("ms");
+  });
+
+  it("emits a single error line on failure", async () => {
+    const mw = new LoggingMiddleware("INFO", mockLogger);
+    const ctx = makeMiddlewareContext({ requestId: "req-99" });
+
+    await expect(
+      mw.handle(ctx, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    const [meta, msg] = mockLogger.error.mock.calls[0];
+    expect(meta.method).toBe("tools/call");
+    expect(meta.requestId).toBe("req-99");
+    expect(meta.error).toContain("Error: boom");
+    expect(meta.elapsed).toMatch(/^\d+\.\d+ms$/);
+    expect(msg).toContain("tools/call");
+  });
+
+  it("uses debug level when configured", async () => {
+    const mw = new LoggingMiddleware("DEBUG", mockLogger);
+    const ctx = makeMiddlewareContext();
+
+    await mw.handle(ctx, async () => "ok");
+
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it("passes through the handler result", async () => {
+    const mw = new LoggingMiddleware("INFO", mockLogger);
+    const ctx = makeMiddlewareContext();
+
+    const result = await mw.handle(ctx, async () => ({ data: 42 }));
+
+    expect(result).toEqual({ data: 42 });
+  });
+
+  it("does not log before the handler completes", async () => {
+    const mw = new LoggingMiddleware("INFO", mockLogger);
+    const ctx = makeMiddlewareContext();
+
+    await mw.handle(ctx, async () => {
+      expect(mockLogger.info).not.toHaveBeenCalled();
+      return "ok";
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **Combined log lines**: Middleware now emits one log line per request (after completion) instead of separate `[REQUEST]` and `[RESPONSE]` lines, including method, timing, and session info in a single entry.
- **Missing secrets warning**: Logs a WARN when a tool is called but required secrets are not found in env.
- **Auth failure warning**: Upgraded auth resolution failure from DEBUG to WARN level with tool name and provider.
- **Tests**: Added `tests/middleware/logging.test.ts` with 5 tests covering success, error, debug level, passthrough, and pre-handler silence.

## Test plan
- [x] `bunx tsc --noEmit` — types check clean
- [x] `bun test` — 453 tests pass, 0 fail
- [x] `bunx biome check --write .` — no fixes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)