### PR TITLE
fix: match Python wire format for _meta.arcade.requirements.authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeai/arcade-mcp",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "TypeScript MCP framework with secret injection, OAuth auth providers, multi-user support, worker routes, and middleware",
   "type": "module",
   "bin": {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -50,6 +50,30 @@ export function createMcpToolConfig(tool: MaterializedTool): McpToolConfig {
 }
 
 /**
+ * Convert a ToolAuthorization to the Python-compatible wire format
+ * used in `_meta.arcade.requirements.authorization`.
+ *
+ * Mapping:
+ *   providerId  → provider_id
+ *   providerType → provider_type
+ *   id          → id
+ *   scopes      → oauth2.scopes  (nested under provider type key)
+ */
+function toWireAuthorization(
+  auth: import("./auth/types.js").ToolAuthorization,
+): Record<string, unknown> {
+  const wire: Record<string, unknown> = {
+    provider_id: auth.providerId,
+    provider_type: auth.providerType,
+  };
+  if (auth.id !== undefined) wire.id = auth.id;
+  if (auth.scopes?.length) {
+    wire[auth.providerType] = { scopes: auth.scopes };
+  }
+  return wire;
+}
+
+/**
  * Build the `_meta.arcade` structure from a MaterializedTool's
  * requirements (auth, secrets, metadata) and behavioral metadata.
  *
@@ -62,7 +86,7 @@ export function buildArcadeMeta(
 
   // Requirements
   const requirements: Record<string, unknown> = {};
-  if (tool.auth) requirements.authorization = tool.auth;
+  if (tool.auth) requirements.authorization = toWireAuthorization(tool.auth);
   if (tool.secrets?.length) requirements.secrets = tool.secrets;
   if (tool.metadata && Object.keys(tool.metadata).length > 0)
     requirements.metadata = tool.metadata;

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -372,9 +372,9 @@ describe("toToolDefinition with convert metadata", () => {
       arcade: {
         requirements: {
           authorization: {
-            providerId: "github",
-            providerType: "oauth2",
-            scopes: ["repo"],
+            provider_id: "github",
+            provider_type: "oauth2",
+            oauth2: { scopes: ["repo"] },
           },
           secrets: ["GH_TOKEN"],
         },

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -102,9 +102,9 @@ describe("createMcpToolConfig", () => {
       arcade: {
         requirements: {
           authorization: {
-            providerId: "github",
-            providerType: "oauth2",
-            scopes: ["repo"],
+            provider_id: "github",
+            provider_type: "oauth2",
+            oauth2: { scopes: ["repo"] },
           },
         },
       },
@@ -151,9 +151,9 @@ describe("createMcpToolConfig", () => {
     expect(config._meta?.arcade).toEqual({
       requirements: {
         authorization: {
-          providerId: "github",
-          providerType: "oauth2",
-          scopes: ["repo"],
+          provider_id: "github",
+          provider_type: "oauth2",
+          oauth2: { scopes: ["repo"] },
         },
         secrets: ["TOKEN"],
       },
@@ -184,9 +184,49 @@ describe("buildArcadeMeta", () => {
 
     expect(meta?.requirements).toEqual({
       authorization: {
-        providerId: "google",
-        providerType: "oauth2",
-        scopes: ["email"],
+        provider_id: "google",
+        provider_type: "oauth2",
+        oauth2: { scopes: ["email"] },
+      },
+    });
+  });
+
+  it("includes authorization without scopes (no oauth2 key)", () => {
+    const meta = buildArcadeMeta(
+      makeTool({
+        auth: {
+          providerId: "github",
+          providerType: "oauth2",
+        },
+      }),
+    );
+
+    expect(meta?.requirements).toEqual({
+      authorization: {
+        provider_id: "github",
+        provider_type: "oauth2",
+      },
+    });
+  });
+
+  it("includes authorization with id field", () => {
+    const meta = buildArcadeMeta(
+      makeTool({
+        auth: {
+          providerId: "google",
+          providerType: "oauth2",
+          id: "my-google",
+          scopes: ["email"],
+        },
+      }),
+    );
+
+    expect(meta?.requirements).toEqual({
+      authorization: {
+        provider_id: "google",
+        provider_type: "oauth2",
+        id: "my-google",
+        oauth2: { scopes: ["email"] },
       },
     });
   });


### PR DESCRIPTION
## Summary

- Fixes `_meta.arcade.requirements.authorization` wire format to match Python's `ToolAuthRequirement.model_dump()` output
- Converts camelCase keys (`providerId`, `providerType`) to snake_case (`provider_id`, `provider_type`)
- Nests `scopes` under the provider type key (e.g. `oauth2: { scopes: [...] }`) instead of flat on the authorization object
- Adds `toWireAuthorization()` helper in `src/convert.ts` that keeps internal TS types idiomatic while producing Python-compatible wire format
- Adds test coverage for auth without scopes and auth with `id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)